### PR TITLE
adding DbConnect mocha tests

### DIFF
--- a/back-end-main/app/Models/DbConnect.js
+++ b/back-end-main/app/Models/DbConnect.js
@@ -8,34 +8,32 @@ class DbConnector{
     {
         return this.port;
     }
-    
+
     getIp()
     {
         return this.IP;
     }
-    
+
     getAllMsgs(roomID)
     {
         // sql stuff
         return null;
     }
-    
+
     getMsg(msgID)
     {
         return null;
     }
-    
+
     sendMsg(msg)
     {
         return null;
     }
-    
+
     deleteMsg(msg)
     {
         return null;
     }
-    
-    
-    
-    
 }
+// exports class DbConnector to be used by other .js files 
+module.exports = DbConnector;

--- a/back-end-main/test/DbConnectTest.js
+++ b/back-end-main/test/DbConnectTest.js
@@ -1,0 +1,44 @@
+const assert = require('chai').assert;
+const DbConnect = require('../app/Models/DbConnect');
+
+describe('DbConnector', function() {
+    const ip = '127.0.0.1';
+    const port = '8080';
+    let connector = new DbConnect(port, ip);
+
+    describe("getPort", function() {
+      it('getPort should return 8080', function(){
+        assert.equal(connector.getPort(), '8080');
+      })
+    })
+
+    describe("getIp", function() {
+      it('getIP should return 127.0.0.1', function(){
+        assert.equal(connector.getIp(), '127.0.0.1');
+      })
+    })
+
+    describe("getAllMsgs", function() {
+      it('getALLMsgs should return true', function(){
+        assert.equal(connector.getAllMsgs(), true);
+      })
+    })
+
+    describe("getMsg", function() {
+      it('getMsgs should return true', function(){
+        assert.equal(connector.getMsg(), true);
+      })
+    })
+
+    describe("sendMsg", function() {
+      it('sendMsg should return true', function(){
+        assert.equal(connector.sendMsg(), true);
+      })
+    })
+
+    describe("deleteMsg", function() {
+      it('deleteMsg should return true', function(){
+        assert.equal(connector.deleteMsg(), true);
+      })
+    })
+})


### PR DESCRIPTION
The tests are currently set up to fail since we haven't implemented all msgs() through deleteMsg() functions. getPort() and getIp() are being tested by creating a DbConnector and calling the functions to return this.port &  this.IP. I tried to figure out how to test the constructor independently, but it's not really necessary since get functions use the constructor. to return values.